### PR TITLE
[#25] feat: header 컴포넌트 구현

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,5 @@
 import type { Preview } from '@storybook/react'
-import '@fontsource/noto-sans-kr/500.css'
+import '@fontsource-variable/noto-sans-kr'
 import '@/styles/globals.css'
 
 const preview: Preview = {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import '@fontsource/noto-sans-kr/500.css'
+import '@fontsource-variable/noto-sans-kr'
 import '@/styles/globals.css'
 
 export const metadata: Metadata = {

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,0 +1,16 @@
+interface HeaderProps {
+  children: string
+}
+
+function Header({ children }: HeaderProps) {
+  return (
+    <header className="header flex w-screen items-center justify-between bg-white px-40pxr py-8pxr">
+      <div className="flex h-40pxr w-80pxr items-center justify-center bg-[#e6e6e6]">
+        로고
+      </div>
+      <h1 className="text-24pxr font-bold">{children}</h1>
+    </header>
+  )
+}
+
+export default Header

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,5 +1,5 @@
 interface HeaderProps {
-  children: string
+  children?: string
 }
 
 function Header({ children }: HeaderProps) {

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -8,7 +8,7 @@ function Header({ children }: HeaderProps) {
       <div className="flex h-40pxr w-80pxr items-center justify-center bg-[#e6e6e6]">
         로고
       </div>
-      <h1 className="text-24pxr font-bold">{children}</h1>
+      <h1 className="text-24pxr font-bold text-[#49454f]">{children}</h1>
     </header>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vote",
       "version": "0.1.0",
       "dependencies": {
-        "@fontsource/noto-sans-kr": "^5.0.18",
+        "@fontsource-variable/noto-sans-kr": "^5.0.5",
         "mysql2": "^3.9.4",
         "next": "14.1.4",
         "react": "^18",
@@ -2911,10 +2911,10 @@
       "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==",
       "dev": true
     },
-    "node_modules/@fontsource/noto-sans-kr": {
-      "version": "5.0.18",
-      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-kr/-/noto-sans-kr-5.0.18.tgz",
-      "integrity": "sha512-5P2W+NbUYanP41l2U2kc3HUqd+g4MZlXXvxYZnmGEYpO065N/b7CQpCa9kltREjLnxzLauyeF0j7SRAsI11+XQ=="
+    "node_modules/@fontsource-variable/noto-sans-kr": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-kr/-/noto-sans-kr-5.0.5.tgz",
+      "integrity": "sha512-RGwy/mMP9tIJDpVslAdQGnIukDsSm4ojck1KwwKYMZUrDwN/CPC4sWXn/4oMdcYa5C1+aIlbuqKT6rQqozrkyw=="
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test-storybook": "test-storybook"
   },
   "dependencies": {
-    "@fontsource/noto-sans-kr": "^5.0.18",
+    "@fontsource-variable/noto-sans-kr": "^5.0.5",
     "mysql2": "^3.9.4",
     "next": "14.1.4",
     "react": "^18",

--- a/stories/header.stories.tsx
+++ b/stories/header.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import Header from '@/components/header'
+
+const meta = {
+  title: 'Header/header',
+  component: Header,
+  parameters: {
+    layout: 'centered',
+    backgrounds: { default: 'dark' },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ width: '1440px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    children: { control: 'text' },
+  },
+} satisfies Meta<typeof Header>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  args: {
+    children: '투표하기',
+  },
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,9 +3,13 @@
 @tailwind utilities;
 
 body {
-  font-family: 'Noto Sans KR';
+  font-family: 'Noto Sans KR Variable';
 }
 
 input:focus {
   outline: none;
+}
+
+.header::after {
+  content: '';
 }


### PR DESCRIPTION
## 🛠️주요 변경 사항

- noto sans kr 굵기 500만 적용되고 있던 문제
- header 컴포넌트 구현

## 📣리뷰어에게 하고싶은 말

- npm i 해야합니다

## 🖼️스크린샷(선택)

## ❗관련이슈

- close #25
