### PR TITLE
[#115] refactor: 메인페이지 투표 아이템 받아오는 개수 8개 => 12개로 변경

### DIFF
--- a/components/main-page-content.tsx
+++ b/components/main-page-content.tsx
@@ -30,7 +30,7 @@ function MainPageContent() {
   const targetRef = useRef<HTMLDivElement>(null)
   const timeoutQueryRef = useRef<NodeJS.Timeout | null>(null)
 
-  const limit = 8
+  const LIMIT = 12
   const itemCounts = voteList.length
   const { observe, unobserve, isVisible, setIsVisible } =
     useIntersectionObserver()
@@ -84,7 +84,7 @@ function MainPageContent() {
       setIsLoading(true)
       const response = await getVotelist({
         offset,
-        limit,
+        limit: LIMIT,
         search: query,
         order,
       })
@@ -94,7 +94,7 @@ function MainPageContent() {
       setHasNext(hasMoreItems)
       setVoteList((prev) => [...prev, ...votes])
       setTotalCount(total)
-      setOffset((prev) => prev + limit)
+      setOffset((prev) => prev + LIMIT)
       setIsVisible(false)
       setIsLoading(false)
     }

--- a/cypress/e2e/vote-main.cy.ts
+++ b/cypress/e2e/vote-main.cy.ts
@@ -2,7 +2,7 @@ describe('메인페이지를 테스트 한다.', () => {
   beforeEach(() => {
     cy.intercept(
       'GET',
-      'https://vote-server.xyz/api/votelist?offset=1&limit=8',
+      'https://vote-server.xyz/api/votelist?offset=1&limit=12',
       {
         statusCode: 200,
         fixture: 'votelist-8.json',
@@ -11,7 +11,7 @@ describe('메인페이지를 테스트 한다.', () => {
 
     cy.intercept(
       'GET',
-      'https://vote-server.xyz/api/votelist?offset=9&limit=8',
+      'https://vote-server.xyz/api/votelist?offset=9&limit=12',
       {
         statusCode: 200,
         fixture: 'votelist-16.json',
@@ -20,7 +20,7 @@ describe('메인페이지를 테스트 한다.', () => {
 
     cy.intercept(
       'GET',
-      'https://vote-server.xyz/api/votelist?offset=1&limit=8&search=%ED%85%8C%EC%8A%A4%ED%8A%B8%203&order=popular',
+      'https://vote-server.xyz/api/votelist?offset=1&limit=12&search=%ED%85%8C%EC%8A%A4%ED%8A%B8%203&order=popular',
       {
         statusCode: 200,
         fixture: 'votelist-search.json',
@@ -76,14 +76,14 @@ describe('메인페이지를 테스트 한다.', () => {
 
   it('무한 스크롤을 테스트한다.', () => {
     cy.wait(1500)
-    cy.get('@voteCard').should('have.length', 8)
+    cy.get('@voteCard').should('have.length', 12)
 
     cy.scrollTo('bottom')
 
-    cy.get('@voteCard').should('have.length.gte', 8)
+    cy.get('@voteCard').should('have.length.gte', 12)
 
     cy.scrollTo('bottom')
 
-    cy.get('@voteCard').should('have.length.gte', 16)
+    cy.get('@voteCard').should('have.length.gte', 24)
   })
 })


### PR DESCRIPTION
## 🛠️주요 변경 사항

- 메인페이지 투표 아이템 받아오는 개수 8개 => 12개로 변경

## 📣리뷰어에게 하고싶은 말

-

## 🖼️스크린샷(선택)

## ❗관련이슈

- close #115
